### PR TITLE
migrated v2 resources to using apiextensions types

### DIFF
--- a/service/resource/configmapv2/create.go
+++ b/service/resource/configmapv2/create.go
@@ -1,4 +1,4 @@
-package configmapv1
+package configmapv2
 
 import (
 	"context"

--- a/service/resource/configmapv2/current.go
+++ b/service/resource/configmapv2/current.go
@@ -1,4 +1,4 @@
-package configmapv1
+package configmapv2
 
 import (
 	"context"

--- a/service/resource/configmapv2/delete.go
+++ b/service/resource/configmapv2/delete.go
@@ -1,4 +1,4 @@
-package configmapv1
+package configmapv2
 
 import (
 	"context"

--- a/service/resource/configmapv2/delete_test.go
+++ b/service/resource/configmapv2/delete_test.go
@@ -1,15 +1,11 @@
-package configmapv1
+package configmapv2
 
 import (
 	"context"
 	"reflect"
 	"testing"
 
-	"github.com/giantswarm/ingresstpr"
-	"github.com/giantswarm/ingresstpr/guestcluster"
-	"github.com/giantswarm/ingresstpr/hostcluster"
-	"github.com/giantswarm/ingresstpr/hostcluster/ingresscontroller"
-	"github.com/giantswarm/ingresstpr/protocolport"
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/micrologger/microloggertest"
 	"k8s.io/client-go/kubernetes/fake"
 	apiv1 "k8s.io/client-go/pkg/api/v1"
@@ -25,21 +21,21 @@ func Test_Service_newDeleteChange(t *testing.T) {
 	}{
 		// Test 0.
 		{
-			Obj: &ingresstpr.CustomObject{
-				Spec: ingresstpr.Spec{
-					GuestCluster: guestcluster.GuestCluster{
+			Obj: &v1alpha1.Ingress{
+				Spec: v1alpha1.IngressSpec{
+					GuestCluster: v1alpha1.IngressSpecGuestCluster{
 						ID:        "al9qy",
 						Namespace: "al9qy",
 						Service:   "worker",
 					},
-					HostCluster: hostcluster.HostCluster{
-						IngressController: ingresscontroller.IngressController{
+					HostCluster: v1alpha1.IngressSpecHostCluster{
+						IngressController: v1alpha1.IngressSpecHostClusterIngressController{
 							ConfigMap: "ingress-controller",
 							Namespace: "kube-system",
 							Service:   "ingress-controller",
 						},
 					},
-					ProtocolPorts: []protocolport.ProtocolPort{
+					ProtocolPorts: []v1alpha1.IngressSpecProtocolPort{
 						{
 							IngressPort: 30010,
 							Protocol:    "http",
@@ -67,21 +63,21 @@ func Test_Service_newDeleteChange(t *testing.T) {
 
 		// Test 1.
 		{
-			Obj: &ingresstpr.CustomObject{
-				Spec: ingresstpr.Spec{
-					GuestCluster: guestcluster.GuestCluster{
+			Obj: &v1alpha1.Ingress{
+				Spec: v1alpha1.IngressSpec{
+					GuestCluster: v1alpha1.IngressSpecGuestCluster{
 						ID:        "p1l6x",
 						Namespace: "p1l6x",
 						Service:   "worker",
 					},
-					HostCluster: hostcluster.HostCluster{
-						IngressController: ingresscontroller.IngressController{
+					HostCluster: v1alpha1.IngressSpecHostCluster{
+						IngressController: v1alpha1.IngressSpecHostClusterIngressController{
 							ConfigMap: "ingress-controller",
 							Namespace: "kube-system",
 							Service:   "ingress-controller",
 						},
 					},
-					ProtocolPorts: []protocolport.ProtocolPort{
+					ProtocolPorts: []v1alpha1.IngressSpecProtocolPort{
 						{
 							IngressPort: 30010,
 							Protocol:    "http",

--- a/service/resource/configmapv2/desired.go
+++ b/service/resource/configmapv2/desired.go
@@ -1,4 +1,4 @@
-package configmapv1
+package configmapv2
 
 import (
 	"context"

--- a/service/resource/configmapv2/desired_test.go
+++ b/service/resource/configmapv2/desired_test.go
@@ -1,15 +1,11 @@
-package configmapv1
+package configmapv2
 
 import (
 	"context"
 	"reflect"
 	"testing"
 
-	"github.com/giantswarm/ingresstpr"
-	"github.com/giantswarm/ingresstpr/guestcluster"
-	"github.com/giantswarm/ingresstpr/hostcluster"
-	"github.com/giantswarm/ingresstpr/hostcluster/ingresscontroller"
-	"github.com/giantswarm/ingresstpr/protocolport"
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/micrologger/microloggertest"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -22,21 +18,21 @@ func Test_Service_GetDesiredState(t *testing.T) {
 	}{
 		// Test 0.
 		{
-			Obj: &ingresstpr.CustomObject{
-				Spec: ingresstpr.Spec{
-					GuestCluster: guestcluster.GuestCluster{
+			Obj: &v1alpha1.Ingress{
+				Spec: v1alpha1.IngressSpec{
+					GuestCluster: v1alpha1.IngressSpecGuestCluster{
 						ID:        "al9qy",
 						Namespace: "al9qy",
 						Service:   "worker",
 					},
-					HostCluster: hostcluster.HostCluster{
-						IngressController: ingresscontroller.IngressController{
+					HostCluster: v1alpha1.IngressSpecHostCluster{
+						IngressController: v1alpha1.IngressSpecHostClusterIngressController{
 							ConfigMap: "ingress-controller",
 							Namespace: "kube-system",
 							Service:   "ingress-controller",
 						},
 					},
-					ProtocolPorts: []protocolport.ProtocolPort{
+					ProtocolPorts: []v1alpha1.IngressSpecProtocolPort{
 						{
 							IngressPort: 30010,
 							Protocol:    "http",
@@ -53,21 +49,21 @@ func Test_Service_GetDesiredState(t *testing.T) {
 
 		// Test 1.
 		{
-			Obj: &ingresstpr.CustomObject{
-				Spec: ingresstpr.Spec{
-					GuestCluster: guestcluster.GuestCluster{
+			Obj: &v1alpha1.Ingress{
+				Spec: v1alpha1.IngressSpec{
+					GuestCluster: v1alpha1.IngressSpecGuestCluster{
 						ID:        "p1l6x",
 						Namespace: "p1l6x",
 						Service:   "worker",
 					},
-					HostCluster: hostcluster.HostCluster{
-						IngressController: ingresscontroller.IngressController{
+					HostCluster: v1alpha1.IngressSpecHostCluster{
+						IngressController: v1alpha1.IngressSpecHostClusterIngressController{
 							ConfigMap: "ingress-controller",
 							Namespace: "kube-system",
 							Service:   "ingress-controller",
 						},
 					},
-					ProtocolPorts: []protocolport.ProtocolPort{
+					ProtocolPorts: []v1alpha1.IngressSpecProtocolPort{
 						{
 							IngressPort: 30010,
 							Protocol:    "http",

--- a/service/resource/configmapv2/error.go
+++ b/service/resource/configmapv2/error.go
@@ -1,4 +1,4 @@
-package configmapv1
+package configmapv2
 
 import (
 	"github.com/giantswarm/microerror"

--- a/service/resource/configmapv2/resource.go
+++ b/service/resource/configmapv2/resource.go
@@ -1,12 +1,13 @@
-package configmapv1
+package configmapv2
 
 import (
-	"github.com/giantswarm/ingresstpr"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/operatorkit/framework"
 	"k8s.io/client-go/kubernetes"
 	apiv1 "k8s.io/client-go/pkg/api/v1"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 )
 
 const (
@@ -20,7 +21,7 @@ const (
 	//
 	DataValueFormat = "%s/%s:%d"
 	// Name is the identifier of the resource.
-	Name = "configmap"
+	Name = "configmapv2"
 )
 
 // Config represents the configuration used to create a new config map resource.
@@ -84,10 +85,10 @@ func inConfigMapData(data map[string]string, k, v string) bool {
 	return false
 }
 
-func toCustomObject(v interface{}) (ingresstpr.CustomObject, error) {
-	customObjectPointer, ok := v.(*ingresstpr.CustomObject)
+func toCustomObject(v interface{}) (v1alpha1.Ingress, error) {
+	customObjectPointer, ok := v.(*v1alpha1.Ingress)
 	if !ok {
-		return ingresstpr.CustomObject{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &ingresstpr.CustomObject{}, v)
+		return v1alpha1.Ingress{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &v1alpha1.Ingress{}, v)
 	}
 	customObject := *customObjectPointer
 

--- a/service/resource/configmapv2/update.go
+++ b/service/resource/configmapv2/update.go
@@ -1,4 +1,4 @@
-package configmapv1
+package configmapv2
 
 import (
 	"context"

--- a/service/resource/configmapv2/update_test.go
+++ b/service/resource/configmapv2/update_test.go
@@ -1,15 +1,11 @@
-package configmapv1
+package configmapv2
 
 import (
 	"context"
 	"reflect"
 	"testing"
 
-	"github.com/giantswarm/ingresstpr"
-	"github.com/giantswarm/ingresstpr/guestcluster"
-	"github.com/giantswarm/ingresstpr/hostcluster"
-	"github.com/giantswarm/ingresstpr/hostcluster/ingresscontroller"
-	"github.com/giantswarm/ingresstpr/protocolport"
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/micrologger/microloggertest"
 	"k8s.io/client-go/kubernetes/fake"
 	apiv1 "k8s.io/client-go/pkg/api/v1"
@@ -25,21 +21,21 @@ func Test_Service_newUpdateChange(t *testing.T) {
 	}{
 		// Test 0.
 		{
-			Obj: &ingresstpr.CustomObject{
-				Spec: ingresstpr.Spec{
-					GuestCluster: guestcluster.GuestCluster{
+			Obj: &v1alpha1.Ingress{
+				Spec: v1alpha1.IngressSpec{
+					GuestCluster: v1alpha1.IngressSpecGuestCluster{
 						ID:        "al9qy",
 						Namespace: "al9qy",
 						Service:   "worker",
 					},
-					HostCluster: hostcluster.HostCluster{
-						IngressController: ingresscontroller.IngressController{
+					HostCluster: v1alpha1.IngressSpecHostCluster{
+						IngressController: v1alpha1.IngressSpecHostClusterIngressController{
 							ConfigMap: "ingress-controller",
 							Namespace: "kube-system",
 							Service:   "ingress-controller",
 						},
 					},
-					ProtocolPorts: []protocolport.ProtocolPort{
+					ProtocolPorts: []v1alpha1.IngressSpecProtocolPort{
 						{
 							IngressPort: 30010,
 							Protocol:    "http",
@@ -68,21 +64,21 @@ func Test_Service_newUpdateChange(t *testing.T) {
 
 		// Test 1.
 		{
-			Obj: &ingresstpr.CustomObject{
-				Spec: ingresstpr.Spec{
-					GuestCluster: guestcluster.GuestCluster{
+			Obj: &v1alpha1.Ingress{
+				Spec: v1alpha1.IngressSpec{
+					GuestCluster: v1alpha1.IngressSpecGuestCluster{
 						ID:        "p1l6x",
 						Namespace: "p1l6x",
 						Service:   "worker",
 					},
-					HostCluster: hostcluster.HostCluster{
-						IngressController: ingresscontroller.IngressController{
+					HostCluster: v1alpha1.IngressSpecHostCluster{
+						IngressController: v1alpha1.IngressSpecHostClusterIngressController{
 							ConfigMap: "ingress-controller",
 							Namespace: "kube-system",
 							Service:   "ingress-controller",
 						},
 					},
-					ProtocolPorts: []protocolport.ProtocolPort{
+					ProtocolPorts: []v1alpha1.IngressSpecProtocolPort{
 						{
 							IngressPort: 30010,
 							Protocol:    "http",

--- a/service/resource/servicev2/create.go
+++ b/service/resource/servicev2/create.go
@@ -1,4 +1,4 @@
-package servicev1
+package servicev2
 
 import (
 	"context"

--- a/service/resource/servicev2/current.go
+++ b/service/resource/servicev2/current.go
@@ -1,4 +1,4 @@
-package servicev1
+package servicev2
 
 import (
 	"context"

--- a/service/resource/servicev2/delete.go
+++ b/service/resource/servicev2/delete.go
@@ -1,4 +1,4 @@
-package servicev1
+package servicev2
 
 import (
 	"context"

--- a/service/resource/servicev2/delete_test.go
+++ b/service/resource/servicev2/delete_test.go
@@ -1,15 +1,11 @@
-package servicev1
+package servicev2
 
 import (
 	"context"
 	"reflect"
 	"testing"
 
-	"github.com/giantswarm/ingresstpr"
-	"github.com/giantswarm/ingresstpr/guestcluster"
-	"github.com/giantswarm/ingresstpr/hostcluster"
-	"github.com/giantswarm/ingresstpr/hostcluster/ingresscontroller"
-	"github.com/giantswarm/ingresstpr/protocolport"
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/micrologger/microloggertest"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
@@ -27,21 +23,21 @@ func Test_Service_newDeleteChange(t *testing.T) {
 		// Test 0 ensures that a having a single port in the current state and
 		// having the same port in the desired state, the delete state is empty.
 		{
-			Obj: &ingresstpr.CustomObject{
-				Spec: ingresstpr.Spec{
-					GuestCluster: guestcluster.GuestCluster{
+			Obj: &v1alpha1.Ingress{
+				Spec: v1alpha1.IngressSpec{
+					GuestCluster: v1alpha1.IngressSpecGuestCluster{
 						ID:        "al9qy",
 						Namespace: "al9qy",
 						Service:   "worker",
 					},
-					HostCluster: hostcluster.HostCluster{
-						IngressController: ingresscontroller.IngressController{
+					HostCluster: v1alpha1.IngressSpecHostCluster{
+						IngressController: v1alpha1.IngressSpecHostClusterIngressController{
 							ConfigMap: "ingress-controller",
 							Namespace: "kube-system",
 							Service:   "ingress-controller",
 						},
 					},
-					ProtocolPorts: []protocolport.ProtocolPort{
+					ProtocolPorts: []v1alpha1.IngressSpecProtocolPort{
 						{
 							IngressPort: 30010,
 							Protocol:    "http",
@@ -82,21 +78,21 @@ func Test_Service_newDeleteChange(t *testing.T) {
 
 		// Test 1 is the same as 0 but with multiple ports.
 		{
-			Obj: &ingresstpr.CustomObject{
-				Spec: ingresstpr.Spec{
-					GuestCluster: guestcluster.GuestCluster{
+			Obj: &v1alpha1.Ingress{
+				Spec: v1alpha1.IngressSpec{
+					GuestCluster: v1alpha1.IngressSpecGuestCluster{
 						ID:        "p1l6x",
 						Namespace: "p1l6x",
 						Service:   "worker",
 					},
-					HostCluster: hostcluster.HostCluster{
-						IngressController: ingresscontroller.IngressController{
+					HostCluster: v1alpha1.IngressSpecHostCluster{
+						IngressController: v1alpha1.IngressSpecHostClusterIngressController{
 							ConfigMap: "ingress-controller",
 							Namespace: "kube-system",
 							Service:   "ingress-controller",
 						},
 					},
-					ProtocolPorts: []protocolport.ProtocolPort{
+					ProtocolPorts: []v1alpha1.IngressSpecProtocolPort{
 						{
 							IngressPort: 30010,
 							Protocol:    "http",
@@ -177,21 +173,21 @@ func Test_Service_newDeleteChange(t *testing.T) {
 		// delete state while the rest of the ports of the current state is part of
 		// the delete state.
 		{
-			Obj: &ingresstpr.CustomObject{
-				Spec: ingresstpr.Spec{
-					GuestCluster: guestcluster.GuestCluster{
+			Obj: &v1alpha1.Ingress{
+				Spec: v1alpha1.IngressSpec{
+					GuestCluster: v1alpha1.IngressSpecGuestCluster{
 						ID:        "p1l6x",
 						Namespace: "p1l6x",
 						Service:   "worker",
 					},
-					HostCluster: hostcluster.HostCluster{
-						IngressController: ingresscontroller.IngressController{
+					HostCluster: v1alpha1.IngressSpecHostCluster{
+						IngressController: v1alpha1.IngressSpecHostClusterIngressController{
 							ConfigMap: "ingress-controller",
 							Namespace: "kube-system",
 							Service:   "ingress-controller",
 						},
 					},
-					ProtocolPorts: []protocolport.ProtocolPort{
+					ProtocolPorts: []v1alpha1.IngressSpecProtocolPort{
 						{
 							IngressPort: 30010,
 							Protocol:    "http",
@@ -266,21 +262,21 @@ func Test_Service_newDeleteChange(t *testing.T) {
 
 		// Test 3 is the same as 2 but with different ports.
 		{
-			Obj: &ingresstpr.CustomObject{
-				Spec: ingresstpr.Spec{
-					GuestCluster: guestcluster.GuestCluster{
+			Obj: &v1alpha1.Ingress{
+				Spec: v1alpha1.IngressSpec{
+					GuestCluster: v1alpha1.IngressSpecGuestCluster{
 						ID:        "p1l6x",
 						Namespace: "p1l6x",
 						Service:   "worker",
 					},
-					HostCluster: hostcluster.HostCluster{
-						IngressController: ingresscontroller.IngressController{
+					HostCluster: v1alpha1.IngressSpecHostCluster{
+						IngressController: v1alpha1.IngressSpecHostClusterIngressController{
 							ConfigMap: "ingress-controller",
 							Namespace: "kube-system",
 							Service:   "ingress-controller",
 						},
 					},
-					ProtocolPorts: []protocolport.ProtocolPort{
+					ProtocolPorts: []v1alpha1.IngressSpecProtocolPort{
 						{
 							IngressPort: 30010,
 							Protocol:    "http",
@@ -355,21 +351,21 @@ func Test_Service_newDeleteChange(t *testing.T) {
 
 		// Test 4 is the same as 3 but with port names.
 		{
-			Obj: &ingresstpr.CustomObject{
-				Spec: ingresstpr.Spec{
-					GuestCluster: guestcluster.GuestCluster{
+			Obj: &v1alpha1.Ingress{
+				Spec: v1alpha1.IngressSpec{
+					GuestCluster: v1alpha1.IngressSpecGuestCluster{
 						ID:        "p1l6x",
 						Namespace: "p1l6x",
 						Service:   "worker",
 					},
-					HostCluster: hostcluster.HostCluster{
-						IngressController: ingresscontroller.IngressController{
+					HostCluster: v1alpha1.IngressSpecHostCluster{
+						IngressController: v1alpha1.IngressSpecHostClusterIngressController{
 							ConfigMap: "ingress-controller",
 							Namespace: "kube-system",
 							Service:   "ingress-controller",
 						},
 					},
-					ProtocolPorts: []protocolport.ProtocolPort{
+					ProtocolPorts: []v1alpha1.IngressSpecProtocolPort{
 						{
 							IngressPort: 30010,
 							Protocol:    "http",

--- a/service/resource/servicev2/desired.go
+++ b/service/resource/servicev2/desired.go
@@ -1,4 +1,4 @@
-package servicev1
+package servicev2
 
 import (
 	"context"

--- a/service/resource/servicev2/desired_test.go
+++ b/service/resource/servicev2/desired_test.go
@@ -1,15 +1,11 @@
-package servicev1
+package servicev2
 
 import (
 	"context"
 	"reflect"
 	"testing"
 
-	"github.com/giantswarm/ingresstpr"
-	"github.com/giantswarm/ingresstpr/guestcluster"
-	"github.com/giantswarm/ingresstpr/hostcluster"
-	"github.com/giantswarm/ingresstpr/hostcluster/ingresscontroller"
-	"github.com/giantswarm/ingresstpr/protocolport"
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/micrologger/microloggertest"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
@@ -24,21 +20,21 @@ func Test_Service_GetDesiredState(t *testing.T) {
 	}{
 		// Test 0.
 		{
-			Obj: &ingresstpr.CustomObject{
-				Spec: ingresstpr.Spec{
-					GuestCluster: guestcluster.GuestCluster{
+			Obj: &v1alpha1.Ingress{
+				Spec: v1alpha1.IngressSpec{
+					GuestCluster: v1alpha1.IngressSpecGuestCluster{
 						ID:        "al9qy",
 						Namespace: "al9qy",
 						Service:   "worker",
 					},
-					HostCluster: hostcluster.HostCluster{
-						IngressController: ingresscontroller.IngressController{
+					HostCluster: v1alpha1.IngressSpecHostCluster{
+						IngressController: v1alpha1.IngressSpecHostClusterIngressController{
 							ConfigMap: "ingress-controller",
 							Namespace: "kube-system",
 							Service:   "ingress-controller",
 						},
 					},
-					ProtocolPorts: []protocolport.ProtocolPort{
+					ProtocolPorts: []v1alpha1.IngressSpecProtocolPort{
 						{
 							IngressPort: 30010,
 							Protocol:    "http",
@@ -61,21 +57,21 @@ func Test_Service_GetDesiredState(t *testing.T) {
 
 		// Test 1.
 		{
-			Obj: &ingresstpr.CustomObject{
-				Spec: ingresstpr.Spec{
-					GuestCluster: guestcluster.GuestCluster{
+			Obj: &v1alpha1.Ingress{
+				Spec: v1alpha1.IngressSpec{
+					GuestCluster: v1alpha1.IngressSpecGuestCluster{
 						ID:        "p1l6x",
 						Namespace: "p1l6x",
 						Service:   "worker",
 					},
-					HostCluster: hostcluster.HostCluster{
-						IngressController: ingresscontroller.IngressController{
+					HostCluster: v1alpha1.IngressSpecHostCluster{
+						IngressController: v1alpha1.IngressSpecHostClusterIngressController{
 							ConfigMap: "ingress-controller",
 							Namespace: "kube-system",
 							Service:   "ingress-controller",
 						},
 					},
-					ProtocolPorts: []protocolport.ProtocolPort{
+					ProtocolPorts: []v1alpha1.IngressSpecProtocolPort{
 						{
 							IngressPort: 30010,
 							Protocol:    "http",

--- a/service/resource/servicev2/error.go
+++ b/service/resource/servicev2/error.go
@@ -1,4 +1,4 @@
-package servicev1
+package servicev2
 
 import (
 	"github.com/giantswarm/microerror"

--- a/service/resource/servicev2/resource.go
+++ b/service/resource/servicev2/resource.go
@@ -1,7 +1,7 @@
-package servicev1
+package servicev2
 
 import (
-	"github.com/giantswarm/ingresstpr"
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/operatorkit/framework"
@@ -11,7 +11,7 @@ import (
 
 const (
 	// Name is the identifier of the resource.
-	Name = "service"
+	Name = "servicev2"
 	// PortNameFormat is the format string used to create a service port name. It
 	// combines the protocol, the port of the ingress controller within the guest
 	// cluster and the guest cluster ID, in this order. E.g.:
@@ -93,10 +93,10 @@ func getServicePortByPort(list []apiv1.ServicePort, item int32) (apiv1.ServicePo
 	return apiv1.ServicePort{}, microerror.Maskf(servicePortNotFoundError, "no service port with port '%d'", item)
 }
 
-func toCustomObject(v interface{}) (ingresstpr.CustomObject, error) {
-	customObjectPointer, ok := v.(*ingresstpr.CustomObject)
+func toCustomObject(v interface{}) (v1alpha1.Ingress, error) {
+	customObjectPointer, ok := v.(*v1alpha1.Ingress)
 	if !ok {
-		return ingresstpr.CustomObject{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &ingresstpr.CustomObject{}, v)
+		return v1alpha1.Ingress{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &v1alpha1.Ingress{}, v)
 	}
 	customObject := *customObjectPointer
 

--- a/service/resource/servicev2/update.go
+++ b/service/resource/servicev2/update.go
@@ -1,4 +1,4 @@
-package servicev1
+package servicev2
 
 import (
 	"context"

--- a/service/resource/servicev2/update_test.go
+++ b/service/resource/servicev2/update_test.go
@@ -1,15 +1,11 @@
-package servicev1
+package servicev2
 
 import (
 	"context"
 	"reflect"
 	"testing"
 
-	"github.com/giantswarm/ingresstpr"
-	"github.com/giantswarm/ingresstpr/guestcluster"
-	"github.com/giantswarm/ingresstpr/hostcluster"
-	"github.com/giantswarm/ingresstpr/hostcluster/ingresscontroller"
-	"github.com/giantswarm/ingresstpr/protocolport"
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/micrologger/microloggertest"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
@@ -27,21 +23,21 @@ func Test_Service_newUpdateChange(t *testing.T) {
 		// Test 0 ensures that having one port in the current state and having the
 		// same port in the desired state, the update state should be empty.
 		{
-			Obj: &ingresstpr.CustomObject{
-				Spec: ingresstpr.Spec{
-					GuestCluster: guestcluster.GuestCluster{
+			Obj: &v1alpha1.Ingress{
+				Spec: v1alpha1.IngressSpec{
+					GuestCluster: v1alpha1.IngressSpecGuestCluster{
 						ID:        "al9qy",
 						Namespace: "al9qy",
 						Service:   "worker",
 					},
-					HostCluster: hostcluster.HostCluster{
-						IngressController: ingresscontroller.IngressController{
+					HostCluster: v1alpha1.IngressSpecHostCluster{
+						IngressController: v1alpha1.IngressSpecHostClusterIngressController{
 							ConfigMap: "ingress-controller",
 							Namespace: "kube-system",
 							Service:   "ingress-controller",
 						},
 					},
-					ProtocolPorts: []protocolport.ProtocolPort{
+					ProtocolPorts: []v1alpha1.IngressSpecProtocolPort{
 						{
 							IngressPort: 30010,
 							Protocol:    "http",
@@ -78,21 +74,21 @@ func Test_Service_newUpdateChange(t *testing.T) {
 
 		// Test 1 is the same as 0 but with multiple ports.
 		{
-			Obj: &ingresstpr.CustomObject{
-				Spec: ingresstpr.Spec{
-					GuestCluster: guestcluster.GuestCluster{
+			Obj: &v1alpha1.Ingress{
+				Spec: v1alpha1.IngressSpec{
+					GuestCluster: v1alpha1.IngressSpecGuestCluster{
 						ID:        "p1l6x",
 						Namespace: "p1l6x",
 						Service:   "worker",
 					},
-					HostCluster: hostcluster.HostCluster{
-						IngressController: ingresscontroller.IngressController{
+					HostCluster: v1alpha1.IngressSpecHostCluster{
+						IngressController: v1alpha1.IngressSpecHostClusterIngressController{
 							ConfigMap: "ingress-controller",
 							Namespace: "kube-system",
 							Service:   "ingress-controller",
 						},
 					},
-					ProtocolPorts: []protocolport.ProtocolPort{
+					ProtocolPorts: []v1alpha1.IngressSpecProtocolPort{
 						{
 							IngressPort: 30010,
 							Protocol:    "http",
@@ -168,21 +164,21 @@ func Test_Service_newUpdateChange(t *testing.T) {
 		// Test 2 ensures that an empty current state causes the port of the desired
 		// state to be added to the update state.
 		{
-			Obj: &ingresstpr.CustomObject{
-				Spec: ingresstpr.Spec{
-					GuestCluster: guestcluster.GuestCluster{
+			Obj: &v1alpha1.Ingress{
+				Spec: v1alpha1.IngressSpec{
+					GuestCluster: v1alpha1.IngressSpecGuestCluster{
 						ID:        "al9qy",
 						Namespace: "al9qy",
 						Service:   "worker",
 					},
-					HostCluster: hostcluster.HostCluster{
-						IngressController: ingresscontroller.IngressController{
+					HostCluster: v1alpha1.IngressSpecHostCluster{
+						IngressController: v1alpha1.IngressSpecHostClusterIngressController{
 							ConfigMap: "ingress-controller",
 							Namespace: "kube-system",
 							Service:   "ingress-controller",
 						},
 					},
-					ProtocolPorts: []protocolport.ProtocolPort{
+					ProtocolPorts: []v1alpha1.IngressSpecProtocolPort{
 						{
 							IngressPort: 30010,
 							Protocol:    "http",
@@ -225,21 +221,21 @@ func Test_Service_newUpdateChange(t *testing.T) {
 		// two new ports in the desired state, the update state contains a
 		// composition of these three ports.
 		{
-			Obj: &ingresstpr.CustomObject{
-				Spec: ingresstpr.Spec{
-					GuestCluster: guestcluster.GuestCluster{
+			Obj: &v1alpha1.Ingress{
+				Spec: v1alpha1.IngressSpec{
+					GuestCluster: v1alpha1.IngressSpecGuestCluster{
 						ID:        "p1l6x",
 						Namespace: "p1l6x",
 						Service:   "worker",
 					},
-					HostCluster: hostcluster.HostCluster{
-						IngressController: ingresscontroller.IngressController{
+					HostCluster: v1alpha1.IngressSpecHostCluster{
+						IngressController: v1alpha1.IngressSpecHostClusterIngressController{
 							ConfigMap: "ingress-controller",
 							Namespace: "kube-system",
 							Service:   "ingress-controller",
 						},
 					},
-					ProtocolPorts: []protocolport.ProtocolPort{
+					ProtocolPorts: []v1alpha1.IngressSpecProtocolPort{
 						{
 							IngressPort: 30010,
 							Protocol:    "http",
@@ -319,21 +315,21 @@ func Test_Service_newUpdateChange(t *testing.T) {
 
 		// Test 4 ensures overwriting orphaned service ports works as expected.
 		{
-			Obj: &ingresstpr.CustomObject{
-				Spec: ingresstpr.Spec{
-					GuestCluster: guestcluster.GuestCluster{
+			Obj: &v1alpha1.Ingress{
+				Spec: v1alpha1.IngressSpec{
+					GuestCluster: v1alpha1.IngressSpecGuestCluster{
 						ID:        "p1l6x",
 						Namespace: "p1l6x",
 						Service:   "worker",
 					},
-					HostCluster: hostcluster.HostCluster{
-						IngressController: ingresscontroller.IngressController{
+					HostCluster: v1alpha1.IngressSpecHostCluster{
+						IngressController: v1alpha1.IngressSpecHostClusterIngressController{
 							ConfigMap: "ingress-controller",
 							Namespace: "kube-system",
 							Service:   "ingress-controller",
 						},
 					},
-					ProtocolPorts: []protocolport.ProtocolPort{
+					ProtocolPorts: []v1alpha1.IngressSpecProtocolPort{
 						{
 							IngressPort: 30010,
 							Protocol:    "http",


### PR DESCRIPTION
This PR implements actual changes to the new v2 resources. Most relevant changes happened to the tests because of all the changed types. I want to get this merged and add a new framework to watch for CRDs using the v2 resources. 