### PR TITLE
removed finalizer

### DIFF
--- a/service/framework.go
+++ b/service/framework.go
@@ -416,9 +416,9 @@ func migrateTPRsToCRDs(logger micrologger.Logger, clientSet *versioned.Clientset
 			cro.TypeMeta.APIVersion = "core.giantswarm.io"
 			cro.TypeMeta.Kind = "IngressConfig"
 			cro.ObjectMeta.Name = tpo.Name
-			cro.ObjectMeta.Finalizers = []string{
-				IngressConfigCleanupFinalizer,
-			}
+			//cro.ObjectMeta.Finalizers = []string{
+			//	IngressConfigCleanupFinalizer,
+			//}
 			cro.Spec.GuestCluster.ID = tpo.Spec.GuestCluster.ID
 			cro.Spec.GuestCluster.Namespace = tpo.Spec.GuestCluster.Namespace
 			cro.Spec.GuestCluster.Service = tpo.Spec.GuestCluster.Service


### PR DESCRIPTION
I noticed that finalizers in our installations behave differently than when I tested back then on my minikube. For now it is safer to just drop them and manage the finalizer logic separately in a unified way.