### PR TITLE
Fix typo in the name of the PSP resource

### DIFF
--- a/helm/ingress-operator-chart/templates/psp.yaml
+++ b/helm/ingress-operator-chart/templates/psp.yaml
@@ -1,7 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: kvm-operator-psp
+  name: ingress-operator-psp
 spec:
   privileged: false
   fsGroup:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2296

Fix the typo in the PSP resource name for ingress operator