### PR TITLE
uses architect rendering for chart yaml version

### DIFF
--- a/helm/ingress-operator-chart/Chart.yaml
+++ b/helm/ingress-operator-chart/Chart.yaml
@@ -1,2 +1,2 @@
 name: ingress-operator-chart
-version: 1.0.0-[[ .SHA ]]
+version: [[ .Version ]]-[[ .SHA ]]


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/3313. Just a preparation PR. Must not be merged just yet. We have to sort `architect` first. 